### PR TITLE
Save character data

### DIFF
--- a/src/components/characterForm.js
+++ b/src/components/characterForm.js
@@ -19,7 +19,7 @@ export default class CharacterForm extends React.Component {
                       <Field
                         name="name"
                         label="Name"
-                        defaultValue=""
+                        defaultValue={JSON.parse(localStorage.getItem('values')).name}
                       >
                           {({ fieldProps }) => <Input { ...fieldProps } />}
                       </Field>

--- a/src/components/characterForm.js
+++ b/src/components/characterForm.js
@@ -4,27 +4,33 @@ import Form, { Field } from "@wedgekit/form";
 
 export default class CharacterForm extends React.Component {
     handleSubmit = async values => {
+        // submit delay
         const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
         await sleep(300);
 
-        localStorage.setItem('values', JSON.stringify(values));
-        window.alert(localStorage.getItem('values'));
+        localStorage.setItem("values", JSON.stringify(values));
+
+        // placeholder for re-route to character sheet
+        window.alert(localStorage.getItem("values"));
     }
     
     render() {
         return (
             <Form onSubmit={ this.handleSubmit }>
-              {({ formProps, dirty, submitting }) => (
+              {({ formProps, submitting }) => (
                   <form { ...formProps }>
                       <Field
                         name="name"
                         label="Name"
-                        defaultValue={JSON.parse(localStorage.getItem('values')).name}
+                        defaultValue={ localStorage.getItem("values")
+                            ?  JSON.parse(localStorage.getItem("values")).name
+                            : "" 
+                        }
                       >
                           {({ fieldProps }) => <Input { ...fieldProps } />}
                       </Field>
-                      <Button domain="primary" type="submit" disabled={ !dirty || submitting }>
-                          Create
+                      <Button domain="primary" type="submit" disabled={ submitting }>
+                          { localStorage.getItem("values") ? "Save" : "Create" }
                       </Button>
                   </form>
               )}

--- a/src/components/characterForm.js
+++ b/src/components/characterForm.js
@@ -4,11 +4,11 @@ import Form, { Field } from "@wedgekit/form";
 
 export default class CharacterForm extends React.Component {
     handleSubmit = async values => {
-        // placeholder for saving to local storage
         const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
         await sleep(300);
-        
-        window.alert(JSON.stringify(values));
+
+        localStorage.setItem('values', JSON.stringify(values));
+        window.alert(localStorage.getItem('values'));
     }
     
     render() {


### PR DESCRIPTION
The character data from the form needs to be saved in [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).



**AT1. When the create button is pressed, the form data is saved to localStorage
AT2. When the form is loaded it initializes with any character data in localStorage
AT3. If the form is initialized with pre-existing data the save button is labeled "Save" instead of "Create"**